### PR TITLE
Navigate to budget page from widget

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import LoadingSpinner from "./components/ui/loading-spinner";
 const Home = lazy(() => import("@/pages/home"));
 const CategoryPage = lazy(() => import("@/pages/category"));
 const NotFound = lazy(() => import("@/pages/not-found"));
+const WeedingBudgetPage = lazy(() => import("@/pages/weeding-budget"));
 
 // Tworzenie routera z użyciem createBrowserRouter zamiast wouter
 const router = createBrowserRouter([
@@ -20,6 +21,10 @@ const router = createBrowserRouter([
   {
     path: "/category/:categoryId",
     element: <CategoryPage />,
+  },
+  {
+    path: "/weeding-budget",
+    element: <WeedingBudgetPage />,
   }
 ]);
 

--- a/client/src/components/budget-widget.tsx
+++ b/client/src/components/budget-widget.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import { apiRequest } from '@/lib/queryClient';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+interface Cost {
+  id: number;
+  name: string;
+  value: number;
+}
+
+const TOTAL_BUDGET = 80000;
+
+const BudgetWidget: React.FC = () => {
+  const navigate = useNavigate();
+
+  const { data: costs = [] } = useQuery<Cost[]>({
+    queryKey: ['/api/costs'],
+    queryFn: () => apiRequest('/api/costs'),
+  });
+
+  const totalSpent = useMemo(() => costs.reduce((sum, c) => sum + c.value, 0), [costs]);
+  const remaining = TOTAL_BUDGET - totalSpent;
+
+  return (
+    <Card
+      className="cursor-pointer hover:shadow-lg transition-shadow"
+      onClick={() => navigate('/weeding-budget')}
+    >
+      <CardHeader>
+        <CardTitle>Budżet Weselny</CardTitle>
+        <CardDescription>
+          Całkowity budżet: {TOTAL_BUDGET.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-lg font-medium">
+          Wydano: {totalSpent.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Pozostało: {remaining.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+        </p>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default BudgetWidget;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -23,7 +23,8 @@ import CategoryList from '@/components/category-list';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { GlobalFab } from '@/components/global-fab';
-import BudgetTracker from '@/components/budget-tracker'; // Import the new component
+import BudgetTracker from '@/components/budget-tracker';
+import BudgetWidget from '@/components/budget-widget';
 
 export default function Home() {
   const { toast } = useToast();
@@ -444,7 +445,10 @@ export default function Home() {
             </Card>
 
             {/* Item 3: Sekcja Budżetu (Bottom-Left) */}
-            <BudgetTracker />
+            <div className="space-y-4">
+              <BudgetWidget />
+              <BudgetTracker />
+            </div>
 
             {/* Item 4: Lista kategorii (Bottom-Right) */}
             <div className="mt-6 md:mt-0"> {/* Remove top margin on desktop */}

--- a/client/src/pages/weeding-budget.tsx
+++ b/client/src/pages/weeding-budget.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiRequest } from '@/lib/queryClient';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import BudgetTracker from '@/components/budget-tracker';
+import {
+  Table,
+  TableBody,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableCell,
+} from '@/components/ui/table';
+
+interface Cost {
+  id: number;
+  name: string;
+  value: number;
+  created_at: string;
+}
+
+const WeedingBudgetPage: React.FC = () => {
+  const { data: costs = [] } = useQuery<Cost[]>({
+    queryKey: ['/api/costs'],
+    queryFn: () => apiRequest('/api/costs'),
+  });
+
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <BudgetTracker />
+      <Card>
+        <CardHeader>
+          <CardTitle>Budżet Weselny</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nazwa</TableHead>
+                <TableHead>Kwota</TableHead>
+                <TableHead>Data dodania</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {costs.map((cost) => (
+                <TableRow key={cost.id}>
+                  <TableCell>{cost.name}</TableCell>
+                  <TableCell>{cost.value.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}</TableCell>
+                  <TableCell>{new Date(cost.created_at).toLocaleDateString('pl-PL')}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default WeedingBudgetPage;

--- a/vercel.json
+++ b/vercel.json
@@ -45,6 +45,28 @@
       "headers": {
         "Access-Control-Allow-Origin": "*"
       }
+    },
+    {
+      "src": "/api/costs",
+      "dest": "api/costs.js",
+      "headers": {
+        "Access-Control-Allow-Origin": "*"
+      }
+    },
+    {
+      "src": "/api/costs/(.*)",
+      "dest": "api/costs.js",
+      "headers": {
+        "Access-Control-Allow-Origin": "*"
+      }
+    },
+    {
+      "src": "/weeding-budget",
+      "dest": "/index.html"
+    },
+    {
+      "src": "/weeding-budget/(.*)",
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add `BudgetWidget` to home page so users can open the budget table

## Testing
- `npm ci`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_684a0fc3d8808325b3c5e095430d8486