### PR TITLE
feat: show recent costs in budget widget

### DIFF
--- a/client/src/components/budget-widget.tsx
+++ b/client/src/components/budget-widget.tsx
@@ -2,12 +2,14 @@ import React, { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
 import { apiRequest } from '@/lib/queryClient';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 
 interface Cost {
   id: number;
   name: string;
   value: number;
+  created_at: string;
 }
 
 const TOTAL_BUDGET = 80000;
@@ -22,12 +24,10 @@ const BudgetWidget: React.FC = () => {
 
   const totalSpent = useMemo(() => costs.reduce((sum, c) => sum + c.value, 0), [costs]);
   const remaining = TOTAL_BUDGET - totalSpent;
+  const recentCosts = useMemo(() => costs.slice(0, 5), [costs]);
 
   return (
-    <Card
-      className="cursor-pointer hover:shadow-lg transition-shadow"
-      onClick={() => navigate('/weeding-budget')}
-    >
+    <Card className="transition-shadow">
       <CardHeader>
         <CardTitle>Budżet Weselny</CardTitle>
         <CardDescription>
@@ -41,6 +41,36 @@ const BudgetWidget: React.FC = () => {
         <p className="text-sm text-muted-foreground">
           Pozostało: {remaining.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
         </p>
+        <div className="mt-6 space-y-4">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            Ostatnie wydatki
+          </h3>
+          {recentCosts.length > 0 ? (
+            <ul className="space-y-3">
+              {recentCosts.map((cost) => (
+                <li
+                  key={cost.id}
+                  className="flex items-center justify-between rounded-lg border border-border bg-muted/40 px-3 py-2"
+                >
+                  <div>
+                    <p className="text-sm font-medium text-foreground">{cost.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {new Date(cost.created_at).toLocaleDateString('pl-PL')}
+                    </p>
+                  </div>
+                  <p className="text-sm font-semibold text-foreground">
+                    {cost.value.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+                  </p>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-sm text-muted-foreground">Brak zapisanych wydatków.</p>
+          )}
+        </div>
+        <div className="mt-6 flex justify-end">
+          <Button onClick={() => navigate('/weeding-budget')}>Więcej</Button>
+        </div>
       </CardContent>
     </Card>
   );

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -23,7 +23,7 @@ import CategoryList from '@/components/category-list';
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { GlobalFab } from '@/components/global-fab';
-import BudgetTracker from '@/components/budget-tracker';
+import BudgetWidget from '@/components/budget-widget';
 
 export default function Home() {
   const { toast } = useToast();
@@ -444,7 +444,7 @@ export default function Home() {
             </Card>
 
             {/* Item 3: Sekcja Budżetu (Bottom-Left) */}
-            <BudgetTracker />
+            <BudgetWidget />
 
             {/* Item 4: Lista kategorii (Bottom-Right) */}
             <div className="mt-6 md:mt-0"> {/* Remove top margin on desktop */}


### PR DESCRIPTION
## Summary
- display the five most recent costs in the budget widget with dates and amounts
- add a dedicated button that links to the budget page
- replace the old budget tracker on the home page with the updated widget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690c7f6ac44483258bc0ed0857903ccf