### PR TITLE
Add pie chart to home budget widget

### DIFF
--- a/client/src/components/budget-tracker.tsx
+++ b/client/src/components/budget-tracker.tsx
@@ -38,7 +38,7 @@ const BudgetTracker: React.FC = () => {
   const { toast } = useToast();
   const [costName, setCostName] = useState('');
   const [costValue, setCostValue] = useState('');
-  const [selectedCategoryId, setSelectedCategoryId] = useState<string>('');
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | undefined>(undefined);
 
   // Fetch costs
   const { data: costs = [], isLoading: isLoadingCosts } = useQuery<Cost[]>({
@@ -59,7 +59,7 @@ const BudgetTracker: React.FC = () => {
       queryClient.invalidateQueries({ queryKey: ['/api/costs'] });
       setCostName('');
       setCostValue('');
-      setSelectedCategoryId('');
+      setSelectedCategoryId(undefined);
       toast({
         title: "Koszt dodany",
         description: "Nowy koszt został pomyślnie dodany.",
@@ -85,8 +85,11 @@ const BudgetTracker: React.FC = () => {
       });
       return;
     }
-    const categoryId = selectedCategoryId ? parseInt(selectedCategoryId, 10) : null;
-    if (selectedCategoryId && Number.isNaN(categoryId)) {
+    const categoryId =
+      !selectedCategoryId || selectedCategoryId === 'uncategorized'
+        ? null
+        : parseInt(selectedCategoryId, 10);
+    if (selectedCategoryId && selectedCategoryId !== 'uncategorized' && Number.isNaN(categoryId)) {
       toast({
         title: "Błąd walidacji",
         description: "Wybierz poprawną kategorię.",
@@ -267,7 +270,7 @@ const BudgetTracker: React.FC = () => {
                   <SelectValue placeholder={isLoadingCategories ? 'Ładowanie kategorii...' : 'Wybierz kategorię (opcjonalnie)'} />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="">Bez kategorii</SelectItem>
+                  <SelectItem value="uncategorized">Bez kategorii</SelectItem>
                   {categories.map((category) => (
                     <SelectItem key={category.id} value={String(category.id)}>
                       {category.name}

--- a/client/src/components/budget-widget.tsx
+++ b/client/src/components/budget-widget.tsx
@@ -26,13 +26,20 @@ const BudgetWidget: React.FC = () => {
     queryFn: () => apiRequest('/api/costs'),
   });
 
-  const totalSpent = useMemo(() => costs.reduce((sum, c) => sum + c.value, 0), [costs]);
+  const sortedCosts = useMemo(
+    () =>
+      [...costs].sort(
+        (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      ),
+    [costs],
+  );
+  const totalSpent = useMemo(() => sortedCosts.reduce((sum, c) => sum + c.value, 0), [sortedCosts]);
   const remaining = TOTAL_BUDGET - totalSpent;
-  const recentCosts = useMemo(() => costs.slice(0, 5), [costs]);
+  const recentCosts = useMemo(() => sortedCosts.slice(0, 5), [sortedCosts]);
 
   const categoryTotals = useMemo(() => {
     const totals = new Map<string, { name: string; total: number }>();
-    costs.forEach((cost) => {
+    sortedCosts.forEach((cost) => {
       const key = cost.category_id != null ? String(cost.category_id) : 'uncategorized';
       const name = cost.category_name ?? (cost.category_id != null ? `Kategoria #${cost.category_id}` : 'Bez kategorii');
       const current = totals.get(key) ?? { name, total: 0 };
@@ -40,7 +47,7 @@ const BudgetWidget: React.FC = () => {
       totals.set(key, current);
     });
     return Array.from(totals.values());
-  }, [costs]);
+  }, [sortedCosts]);
 
   const generateColor = (index: number, total: number): string => {
     const hue = (index * (360 / Math.max(total, 1))) % 360;

--- a/client/src/components/budget-widget.tsx
+++ b/client/src/components/budget-widget.tsx
@@ -1,15 +1,19 @@
 import React, { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { Pie, PieChart } from 'recharts';
 import { apiRequest } from '@/lib/queryClient';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 
 interface Cost {
   id: number;
   name: string;
   value: number;
   created_at: string;
+  category_id?: number | null;
+  category_name?: string | null;
 }
 
 const TOTAL_BUDGET = 80000;
@@ -26,6 +30,52 @@ const BudgetWidget: React.FC = () => {
   const remaining = TOTAL_BUDGET - totalSpent;
   const recentCosts = useMemo(() => costs.slice(0, 5), [costs]);
 
+  const categoryTotals = useMemo(() => {
+    const totals = new Map<string, { name: string; total: number }>();
+    costs.forEach((cost) => {
+      const key = cost.category_id != null ? String(cost.category_id) : 'uncategorized';
+      const name = cost.category_name ?? (cost.category_id != null ? `Kategoria #${cost.category_id}` : 'Bez kategorii');
+      const current = totals.get(key) ?? { name, total: 0 };
+      current.total += cost.value;
+      totals.set(key, current);
+    });
+    return Array.from(totals.values());
+  }, [costs]);
+
+  const generateColor = (index: number, total: number): string => {
+    const hue = (index * (360 / Math.max(total, 1))) % 360;
+    return `hsl(${hue}, 70%, 60%)`;
+  };
+
+  const chartData = useMemo(() => {
+    const slices = categoryTotals.map((category, index) => ({
+      name: category.name,
+      value: category.total,
+      fill: generateColor(index, categoryTotals.length + 1),
+    }));
+    slices.push({
+      name: 'Pozostało',
+      value: Math.max(0, remaining),
+      fill: 'hsl(var(--muted))',
+    });
+    return slices;
+  }, [categoryTotals, remaining]);
+
+  const chartConfig = useMemo(() => {
+    const config: ChartConfig = {};
+    categoryTotals.forEach((category, index) => {
+      config[category.name] = {
+        label: category.name,
+        color: generateColor(index, categoryTotals.length + 1),
+      };
+    });
+    config.Pozostało = {
+      label: 'Pozostało',
+      color: 'hsl(var(--muted))',
+    };
+    return config;
+  }, [categoryTotals]);
+
   return (
     <Card className="transition-shadow">
       <CardHeader>
@@ -35,12 +85,52 @@ const BudgetWidget: React.FC = () => {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <p className="text-lg font-medium">
-          Wydano: {totalSpent.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-        </p>
-        <p className="text-sm text-muted-foreground">
-          Pozostało: {remaining.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
-        </p>
+        <div className="flex flex-col items-center gap-4">
+          <ChartContainer config={chartConfig} className="mx-auto aspect-square h-[180px]">
+            <PieChart>
+              <ChartTooltip
+                cursor={false}
+                content={
+                  <ChartTooltipContent
+                    hideLabel
+                    indicator="dot"
+                    formatter={(value, _name, item) => {
+                      const numericValue = typeof value === 'number' ? value : Number(value) || 0;
+                      const percentage = TOTAL_BUDGET > 0 ? ((numericValue / TOTAL_BUDGET) * 100).toFixed(1) : '0';
+                      const displayName = item?.payload?.name || _name;
+                      return (
+                        <div className="flex flex-col gap-0.5">
+                          <span className="font-medium text-foreground">
+                            {displayName}: {numericValue.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+                          </span>
+                          <span className="text-xs text-muted-foreground">({percentage}% całości)</span>
+                        </div>
+                      );
+                    }}
+                  />
+                }
+              />
+              <Pie
+                data={chartData}
+                dataKey="value"
+                nameKey="name"
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={80}
+                strokeWidth={0}
+              />
+            </PieChart>
+          </ChartContainer>
+          <div className="text-center">
+            <p className="text-lg font-medium">
+              Wydano: {totalSpent.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Pozostało: {remaining.toLocaleString('pl-PL', { style: 'currency', currency: 'PLN' })}
+            </p>
+          </div>
+        </div>
         <div className="mt-6 space-y-4">
           <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide">
             Ostatnie wydatki

--- a/vercel.json
+++ b/vercel.json
@@ -59,6 +59,10 @@
       "headers": {
         "Access-Control-Allow-Origin": "*"
       }
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a pie chart to the home budget widget so the overview matches the detailed page
- aggregate costs by category for the chart and include the remaining budget slice
- keep the list of recent expenses and navigation button alongside the new visual summary

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690c7ece6084832592f83f574a9e984e