### PR TITLE
fix: ukryj podkategorie z listy głównej

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -155,8 +155,9 @@ export default function Home() {
       return [];
     }
     // Filter out any potentially invalid category data and ensure IDs are numbers
+    // Only show main categories (parent_id === null) on the home page
     return categoriesData
-      .filter(cat => cat && typeof cat.id === 'number' && !isNaN(cat.id) && typeof cat.name === 'string')
+      .filter(cat => cat && typeof cat.id === 'number' && !isNaN(cat.id) && typeof cat.name === 'string' && cat.parent_id === null)
       .map(cat => ({
         ...cat,
         // Ensure parent_id is number or null


### PR DESCRIPTION
Dodano filtr w home.tsx, który ukrywa podkategorie (parent_id !== null) z listy kategorii na stronie głównej. Teraz wyświetlane są tylko kategorie główne (parent_id === null).