### PR TITLE
Add note deletion confirmation in category view

### DIFF
--- a/client/src/components/notes-section.tsx
+++ b/client/src/components/notes-section.tsx
@@ -176,19 +176,10 @@ export const NotesSection: React.FC<NotesSectionProps> = ({
   }, []); // No external dependencies needed
 
   const handleDeleteNote = useCallback((id: string) => {
-    // For uncategorized notes, show confirmation dialog
-    if (onlyWithoutCategory) {
-      setNoteToDelete(id);
-      setShowDeleteDialog(true);
-    } else {
-      // For categorized notes, delete directly without confirmation
-      setSwipeStates(prev => ({
-        ...prev,
-        [id]: { touchStart: 0, transform: 0, direction: null }
-      }));
-      deleteNoteMutation.mutate(id);
-    }
-  }, [deleteNoteMutation, onlyWithoutCategory]);
+    // Always show confirmation dialog before deleting a note
+    setNoteToDelete(id);
+    setShowDeleteDialog(true);
+  }, []);
 
   const confirmDeleteNote = useCallback(() => {
     if (noteToDelete) {


### PR DESCRIPTION
Notatki w kategoriach teraz wymagają potwierdzenia przed usunięciem, tak samo jak notatki bez kategorii na stronie głównej.