### PR TITLE
Fix sorting order to ascending from 1

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -163,7 +163,13 @@ export default function Home() {
         ...cat,
         // Ensure parent_id is number or null
         parent_id: typeof cat.parent_id === 'number' ? cat.parent_id : null,
-      }));
+      }))
+      .sort((a, b) => {
+        // Extract leading numbers from category names (e.g., "1. KOŚCIÓŁ" -> 1)
+        const numA = parseInt(a.name.match(/^(\d+)\./)?.[1] || '999999', 10);
+        const numB = parseInt(b.name.match(/^(\d+)\./)?.[1] || '999999', 10);
+        return numA - numB;
+      });
   }, [categoriesData]);
 
   // Function to invalidate categories query


### PR DESCRIPTION
Dodano sortowanie numeryczne dla kategorii według numeru na początku nazwy (np. "1. KOŚCIÓŁ" -> 1). Kategorie będą teraz wyświetlane w kolejności: 1, 2, 3, ..., 10 zamiast alfabetycznie gdzie "10" było przed "1".